### PR TITLE
📤 Update to simpler actions, remove single-folder constraint

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,4 +1,4 @@
-name: curvenote
+name: Curvenote Preview Draft from PR
 on:
   pull_request_target:
     branches: [main]
@@ -7,17 +7,12 @@ permissions:
   pull-requests: write
 jobs:
   publish:
-    uses: curvenote/actions/.github/workflows/publish.yml@v1
+    uses: curvenote/actions/.github/workflows/draft.yml@v1
     with:
-      monorepo: true
       id-pattern-regex: '^morganton-2024-(?:[a-zA-Z0-9-_]{3,15})$'
-      enforce-single-folder: true
-      preview-label: paper
-      submit-label: false
       venue: ncssm-mor
       kind: original
       path: papers/*
-      ref: ${{ github.event.pull_request.head.sha }}
     secrets:
       CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
       GITHUB: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,17 @@
+name: Curvenote Submission from Main
+on:
+  push:
+    branches: ['main']
+permissions:
+  contents: write
+jobs:
+  submit:
+    uses: curvenote/actions/.github/workflows/submit.yml@v1
+    with:
+      id-pattern-regex: '^morganton-2024-(?:[a-zA-Z0-9-_]{3,15})$'
+      venue: ncssm-mor
+      kind: original
+      path: papers/*
+    secrets:
+      CURVENOTE: ${{ secrets.CURVENOTE_TOKEN }}
+      GITHUB: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This swaps this repo to slightly different curvenote actions. One action creates preview builds on PR, the other submits on merge to main.

More importantly, the bigger change here is that I removed `enforce-single-folder: true` so we can now preview/submit multiple papers in one PR.